### PR TITLE
Hyphen with fallback in component file names.

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -4,11 +4,11 @@ import minify  from 'html-minifier';
 import {DataObject, Types} from '../models';
 import requireFromString from 'require-from-string';
 import pug     from 'pug';
+import camelCase from 'camel-case';
 
 const htmlMinifier  = minify.minify;
 const htmlRegex     = /(<template.*?>)([\s\S]*?)(<\/template>)/gm;
 const scriptRegex   = /(<script.*?>)([\s\S]*?)(<\/script>)/gm;
-const templateRegex = /\w*\.vue/g;
 
 function htmlParser(body: string, minify: boolean) {
     const bodyArray    = body.match(htmlRegex) || [];
@@ -99,21 +99,21 @@ function componentParser(templatePath: string, defaults: Object, type: Types) {
                 const body = htmlParser(content, true);
                 content = content.replace(htmlRegex, '');
                 const script = scriptParser(content, defaults, type);
-                const templateArray = templatePath.match(templateRegex) || [];
-
+                const templateArray = templatePath.split('/');
+                
                 if (templateArray.length === 0) {
                     let error = `I had an error processing component templates. in this file \n${templatePath}`;
                     console.error(error);
                     reject(error);
                 }
 
-                let templateName = templateArray[0].replace('\.vue', '');
+                let templateName = templateArray[templateArray.length - 1].replace('.vue', '');
                 let componentScript = script || {};
                 componentScript.template = body;
 
                 resolve({
                     type: type,
-                    name: templateName,
+                    name: camelCase(templateName),
                     script: componentScript
                 });
             }

--- a/lib/utils/checkPathUtils.js
+++ b/lib/utils/checkPathUtils.js
@@ -1,0 +1,41 @@
+// @flow
+import fs from 'fs';
+import paramCase from 'param-case';
+
+function getParamCasePath(path: string): string {
+    // example /Users/foo/code/test/components/componentFile.vue
+    let pathArr = path.split('/');
+
+    // gets the last element componentFile.foo
+    let fileName = pathArr[pathArr.length - 1];
+
+    // gets the actual file name componentFile
+    let newFileName = fileName.split('.vue')[0];
+
+    // paramcases componentFile to component-file and adds. .vue at the end
+    let paramCaseFile = paramCase(newFileName) + '.vue';
+
+    // replaces last element of the array, with the param'd version of the filename
+    pathArr[pathArr.length - 1] = paramCaseFile;
+
+    // returns joined pathname with slashes
+    return pathArr.join('/');
+}
+
+function getCorrectPathForFile(path: string, type: string): string {
+    let paramCasePath = '';
+    if (fs.existsSync(path)) {
+        return path;
+    } else if (fs.existsSync(getParamCasePath(path))) {
+        paramCasePath = getParamCasePath(path);
+        return paramCasePath;
+    } else {
+        let err = `Could not find ${type} file at ${paramCasePath.length > 0 ? paramCasePath : path}`;
+        throw new Error(err);
+    }
+}
+
+export {
+    getParamCasePath,
+    getCorrectPathForFile,
+};

--- a/lib/utils/componentArray.js
+++ b/lib/utils/componentArray.js
@@ -4,19 +4,20 @@ import {
     layoutParser,
     componentParser
 } from '../parser';
+import {getCorrectPathForFile} from './checkPathUtils';
 
 let types = new Types();
 
 function setupComponentArray(componentPath: string, defaults: Defaults) {
     let array = [];
     array.push(layoutParser(defaults.layoutPath, defaults, types.LAYOUT));
-    array.push(componentParser(componentPath, defaults, types.COMPONENT));
+    array.push(componentParser(getCorrectPathForFile(componentPath, 'view'), defaults, types.COMPONENT));
 
     if (defaults.options.vue && defaults.options.vue.components) {
         for (var component in defaults.options.vue.components) {
             if (defaults.options.vue.components.hasOwnProperty(component)) {
                 const componentFile = defaults.componentsDir + defaults.options.vue.components[component] + '.vue';
-                array.push(componentParser(componentFile, defaults, types.SUBCOMPONENT));
+                array.push(componentParser(getCorrectPathForFile(componentFile, 'component'), defaults, types.SUBCOMPONENT));
             }
         }
     }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -10,6 +10,7 @@ import headUtil from './head';
 import setupComponentArray from './componentArray';
 import renderError from './renderError';
 import renderComponents from './renderComponents';
+import {getParamCasePath, getCorrectPathForFile} from './checkPathUtils';
 
 export {
     renderUtil,
@@ -21,5 +22,7 @@ export {
     headUtil,
     setupComponentArray,
     renderError,
-    renderComponents
+    renderComponents,
+    getParamCasePath,
+    getCorrectPathForFile
 };

--- a/lib/utils/render.js
+++ b/lib/utils/render.js
@@ -31,7 +31,7 @@ function layoutUtil(components: Object) {
             layout = component;
             break;
         case types.COMPONENT:
-            layout.script   = component.script;
+            layout.script = component.script;
             break;
         case types.SUBCOMPONENT:
             if (layout.script.components) {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "dependencies": {
     "babel-core": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
+    "camel-case": "^3.0.0",
     "html-minifier": "^3.4.3",
     "param-case": "^2.1.1",
     "pug": "2.0.0-beta11",

--- a/test/index.js
+++ b/test/index.js
@@ -37,7 +37,7 @@ test('Renders Component Promise Array', t => {
 });
 
 test('Express Vue Works', t => {
-    expressVue('component', options, function(error, html) {
+    expressVue(__dirname +'/component', options, function(error, html) {
         if (error) {
             t.fail(error);
         } else {

--- a/test/utils/checkPathUtils.js
+++ b/test/utils/checkPathUtils.js
@@ -19,7 +19,7 @@ test('finds test Path ', t => {
 
 test('shows error for fake test Path ', t => {
     const testPath = __dirname + '/../componentDoesntExist.vue';
-    const errMessage = 'Could not find test file at /Users/danielcherubini/Coding/Node/express-vue/test/utils/../componentDoesntExist.vue'
+    const errMessage = `Could not find test file at ${__dirname}/../componentDoesntExist.vue`
     const err = new Error(errMessage);
 
     // const paramPath = getCorrectPathForFile(testPath, 'test');

--- a/test/utils/checkPathUtils.js
+++ b/test/utils/checkPathUtils.js
@@ -1,0 +1,31 @@
+import test   from 'ava';
+import {
+    getParamCasePath,
+    getCorrectPathForFile
+} from '../../lib/utils';
+
+test('Params Path', t => {
+    const originalPath = '/Users/foo/code/test/components/componentFile.vue';
+    const correctPath  = '/Users/foo/code/test/components/component-file.vue';
+
+    t.is(getParamCasePath(originalPath), correctPath);
+});
+
+test('finds test Path ', t => {
+    const testPath = __dirname + '/../component.vue';
+    const paramPath = getCorrectPathForFile(testPath, 'test');
+    t.pass(typeof paramPath, 'string');
+});
+
+test('shows error for fake test Path ', t => {
+    const testPath = __dirname + '/../componentDoesntExist.vue';
+    const errMessage = 'Could not find test file at /Users/danielcherubini/Coding/Node/express-vue/test/utils/../componentDoesntExist.vue'
+    const err = new Error(errMessage);
+
+    // const paramPath = getCorrectPathForFile(testPath, 'test');
+    const error = t.throws(() => {
+        getCorrectPathForFile(testPath, 'test');
+    }, Error);
+
+    t.is(error.message, errMessage);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,7 +1046,7 @@ callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
-camel-case@3.0.x:
+camel-case@3.0.x, camel-case@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
   dependencies:


### PR DESCRIPTION
Solves #68 

**Example:**
filename: `star-rating.vue` <-- fixed
component dec: `starRating` <-- unchanged because javascript spec is camelCase
global component name `starRating` <-- auto-generated
html: `<star-rating></star-rating>` <-- unchanged