### PR TITLE
adding error stack traces

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -53,7 +53,7 @@ function scriptParser(script: string, defaults: Object, type: Types) {
     const scriptArray = script.match(scriptRegex) || [];
     if (scriptArray.length === 0) {
         let error = `I had an error processing this script.\n${script}`;
-        console.error(error);
+        console.error(new Error(error));
         return null;
     }
     let scriptString  = scriptArray[0].replace(scriptRegex, '$2');
@@ -93,7 +93,7 @@ function componentParser(templatePath: string, defaults: Object, type: Types) {
         fs.readFile(templatePath, 'utf-8', function (err, content) {
             if (err) {
                 let error = `Could Not Find Component, I was expecting it to live here \n${templatePath} \nBut I couldn't find it there, ¯\\_(ツ)_/¯\n\n`;
-                console.error(error);
+                console.error(new Error(error));
                 reject(error);
             } else {
                 const body = htmlParser(content, true);
@@ -103,7 +103,7 @@ function componentParser(templatePath: string, defaults: Object, type: Types) {
 
                 if (templateArray.length === 0) {
                     let error = `I had an error processing component templates. in this file \n${templatePath}`;
-                    console.error(error);
+                    console.error(new Error(error));
                     reject(error);
                 }
 


### PR DESCRIPTION
Wraps parse errors in `new Error` for stack traces that were missing.  Let me know your thoughts.