### PR TITLE
fix a bug that the regular expression 'htmlRegex' can only match a part of codes…

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -7,7 +7,7 @@ import pug     from 'pug';
 import camelCase from 'camel-case';
 
 const htmlMinifier  = minify.minify;
-const htmlRegex     = /(<template.*?>)([\s\S]*?)(<\/template>)/gm;
+const htmlRegex     = /(<template.*?>)([\s\S]*)(<\/template>)/gm;
 const scriptRegex   = /(<script.*?>)([\s\S]*?)(<\/script>)/gm;
 
 function htmlParser(body: string, minify: boolean) {


### PR DESCRIPTION
There is a new feature [·Scoped Slots·](https://vuejs.org/v2/guide/components.html#Scoped-Slots) has appeared in the version 2.1.0 of Vue, if I put  tag `<template scope="props”> … </template>` inside the root tag `<template> … </template>`  of the file index.vue, this regular expression `const htmlRegex = /(<template.*?>)([\s\S]*?)(<\/template>)/gm;` in the file ’express-vue/lib/parser/index.js’ can only match a apart of content of root tag `<template> … </template>`.
The statement `const htmlRegex = /(<template.*?>)([\s\S]*?)(<\/template>)/gm;` could be changed to `const htmlRegex = /(<template.*?>)([\s\S]*)(<\/template>)/gm;`