### PR TITLE
Remove Node.js 8 from Travis and add Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
+  - v12
   - v10
-  - v8
 before_install:
     - npm install -g npm
     - npm install -g codecov


### PR DESCRIPTION
- Removed Node.js 8 from Travis and add Node.js 12